### PR TITLE
Fix: Initialize non-nullable string properties in Address value object

### DIFF
--- a/src/WendoverHOA.Domain/ValueObjects/Address.cs
+++ b/src/WendoverHOA.Domain/ValueObjects/Address.cs
@@ -5,10 +5,10 @@ namespace WendoverHOA.Domain.ValueObjects;
 /// </summary>
 public class Address : IEquatable<Address>
 {
-    public string Street { get; private set; }
-    public string City { get; private set; }
-    public string State { get; private set; }
-    public string ZipCode { get; private set; }
+    public string Street { get; private set; } = string.Empty;
+    public string City { get; private set; } = string.Empty;
+    public string State { get; private set; } = string.Empty;
+    public string ZipCode { get; private set; } = string.Empty;
     public string? Unit { get; private set; }
 
     // Private constructor to enforce creation through factory method


### PR DESCRIPTION
This PR fixes warnings related to non-nullable string properties in the Address value object by properly initializing them with empty strings. This ensures a clean build without warnings.